### PR TITLE
Work around https://github.com/jruby/jruby/issues/8155 in serializer_with_fallback.rb

### DIFF
--- a/activesupport/lib/active_support/messages/serializer_with_fallback.rb
+++ b/activesupport/lib/active_support/messages/serializer_with_fallback.rb
@@ -134,7 +134,7 @@ module ActiveSupport
             def available?
               return @available if defined?(@available)
               silence_warnings { require "active_support/message_pack" }
-              @available = true
+              @available = defined?(ActiveSupport::MessagePack) # https://github.com/jruby/jruby/issues/8155
             rescue LoadError
               @available = false
             end


### PR DESCRIPTION
If the `available?` method is called concurrently from two request threads on JRuby 9.4, a bug in JRuby (https://github.com/jruby/jruby/issues/8155) can cause `@available` to be set to true even if the ActiveSupport::MessagePack module fails to load due to a missing msgpack gem dependency.

Once the module has ended up in this inconsistent state, calls to `dumped?` will raise a NameError. This NameError will then be silently caught in `ActionDispatch::Cookies::SerializedCookieJars#parse`, which will interpret it as a parsing error due to a malformed session cookie, which in turn will cause a new session to be created on each request, and consequently CSRF token validation to fail. In our app, this currently happens around 5–10% of the time after a backend restart, although the exact rate depends strongly on the number and type of concurrent requests made by the frontend when it starts. Diagnosing the cause of these mysterious intermittent CSRF validation issues has been a major pain for us.

This patch works around the JRuby bug by explicitly checking whether the module is defined after calling `Kernel#require`.

Even if/when the JRuby bug is fixed, this double check should still be useful as a preventative measure against similar issues on other platforms, and for users still on affected JRuby versions.